### PR TITLE
Questionably reorganised code for compile time benefits.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -4,10 +4,10 @@ rem TODO: Switch between x86 and x64
 
 set depsDir=P:\Breakout\dependencies
 
-set compilerFlags=/nologo /MT /GR- /Gm- /EHa- /Od /Oi /FC /Zi /WX /W4 /wd4100 /IP:\Breakout\src /I%depsDir%\sdl2\include\
+set compilerFlags=/nologo /Fe:breakout.exe /Fo:breakout.obj /MT /GR- /Gm- /EHa- /Od /Oi /FC /Zi /WX /W4 /wd4100 /IP:\Breakout\src /I%depsDir%\sdl2\include\
 set linkerFlags=/opt:ref /SUBSYSTEM:console /LIBPATH:%depsDir%\sdl2\lib\ sdl2.lib sdl2main.lib sdl2_image.lib sdl2_ttf.lib sdl2_mixer.lib
 
-set files=..\src\breakout.cpp ..\src\entity.cpp ..\src\gui.cpp ..\src\states\gameplay.cpp
+set files=..\src\main.cpp
 
 WHERE cl.exe >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64

--- a/src/breakout.cpp
+++ b/src/breakout.cpp
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <chrono>
 #include <math.h>
 
 #include <SDL/SDL.h>
@@ -117,47 +116,4 @@ bool gameHandleEvents(GameData& gameData)
 	}
 
 	return true;
-}
-
-int main(int argc, char* argv[])
-{
-	GameData gameData = init();
-	gameInit(gameData);
-
-	unsigned int frameCounter = 0;
-	std::chrono::high_resolution_clock::time_point lastTime = std::chrono::high_resolution_clock::now();
-
-	while (gameData.running)
-	{
-		// Calculates delta time
-		std::chrono::high_resolution_clock::time_point currentTime = std::chrono::high_resolution_clock::now();
-		std::chrono::duration<double, std::milli> diff = currentTime - lastTime;
-		gameData.deltaTime = diff.count() / 1000.0;
-		lastTime = currentTime;
-
-		// Text for frame rate
-		frameCounter += 1;
-		if (frameCounter % 20 == 0)
-		{
-			char newFpsText[256];
-			sprintf_s(newFpsText, 256, "Breakout V0.1.0 | %dFPS", (int) (1.0 / gameData.deltaTime));
-			gameData.fpsText.text = newFpsText;
-			updateTextTexture(gameData.renderer, gameData.fpsText);
-
-			frameCounter = 0;
-		}
-
-		gameData.running = gameHandleEvents(gameData);
-
-		switch (gameData.gameState)
-		{
-			case GameState::Gameplay: 
-			{
-				if (gameData.running) gameData.running = gameplayUpdate(gameData);
-				gameplayDraw(gameData);
-			} break;
-		}
-	}
-	
-	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,49 @@
+#include <chrono>
+
+#include "states/gameplay.cpp"
+#include "gui.cpp"
+#include "entity.cpp"
+#include "breakout.cpp"
+
+int main(int argc, char* argv[])
+{
+	GameData gameData = init();
+	gameInit(gameData);
+
+	unsigned int frameCounter = 0;
+	std::chrono::high_resolution_clock::time_point lastTime = std::chrono::high_resolution_clock::now();
+
+	while (gameData.running)
+	{
+		// Calculates delta time
+		std::chrono::high_resolution_clock::time_point currentTime = std::chrono::high_resolution_clock::now();
+		std::chrono::duration<double, std::milli> diff = currentTime - lastTime;
+		gameData.deltaTime = diff.count() / 1000.0;
+		lastTime = currentTime;
+
+		// Text for frame rate
+		frameCounter += 1;
+		if (frameCounter % 20 == 0)
+		{
+			char newFpsText[256];
+			sprintf_s(newFpsText, 256, "Breakout V0.1.0 | %dFPS", (int) (1.0 / gameData.deltaTime));
+			gameData.fpsText.text = newFpsText;
+			updateTextTexture(gameData.renderer, gameData.fpsText);
+
+			frameCounter = 0;
+		}
+
+		gameData.running = gameHandleEvents(gameData);
+
+		switch (gameData.gameState)
+		{
+			case GameState::Gameplay: 
+			{
+				if (gameData.running) gameData.running = gameplayUpdate(gameData);
+				gameplayDraw(gameData);
+			} break;
+		}
+	}
+	
+	return 0;
+}


### PR DESCRIPTION
I don't know if we should do this. It basically halves compile time but messes questionably with the layout of the project.

Instead of compiling each `.cpp` file separately, this makes only one compilation unit and `#include`s all the other `.cpp` files into that file (`main.cpp`).